### PR TITLE
Add the "language" and "image_dir" keys to the

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 composer.lock
+/.idea/


### PR DESCRIPTION
installdef keys ignore list. Additionally, refactor
how to exclude these keys values from the "copy" section. 

I know we chatted about how catering to ModuleBuilder quirks does not belong here. Still, I figured I'd submit a PR anyway because of the logic in method: makeIgnoreInstallDefFileMap, which might be useful.